### PR TITLE
Proposal: Start round-robin distribution with random node

### DIFF
--- a/lib/redis-slave-read/interface/base.rb
+++ b/lib/redis-slave-read/interface/base.rb
@@ -44,7 +44,7 @@ class Redis
           @all = slaves + [@master]
           @nodes = slaves.dup
           @nodes.unshift @master if @read_master
-          @index = 0
+          @index = rand(@nodes.length)
         end
 
         def method_missing(method, *args)

--- a/spec/interface/hiredis_spec.rb
+++ b/spec/interface/hiredis_spec.rb
@@ -26,9 +26,9 @@ describe Redis::SlaveRead::Interface::Hiredis do
     it "should distribute reads between all available slaves" do
       expect(master).to receive(:get).never
       expect(slaves[1]).to receive(:get).twice
-      expect(slaves[0]).to receive(:get).once
+      expect(slaves[0]).to receive(:get).twice
 
-      3.times { subject.get "foo" }
+      4.times { subject.get "foo" }
     end
   end
 


### PR DESCRIPTION
We started using your gem in our Rails app, and realized that it makes a small assumption that doesn't work with our architecture.

We run on several frontend servers, and only a few of our routes need Redis.  The ones that do create a new `Redis::SlaveRead::Interface::Hiredis` instance per request.  Unfortunately, this means the `@index` was being initialized to 0 for every request - so the first read command for every request got directed to the first node in the list.  Subsequent commands within a request would be distributed of course, but most of our API endpoints were already optimized to send only one command (using `MULTI` as necessary) to Redis.

We've mitigated this on our fork by randomizing the starting node for the round-robin distribution.  It's probably a good idea for anyone using this gem though.  If you'd prefer this was made into a configuration option, let me know.

Thank you for building this!  It saved me a bunch of time last week!
